### PR TITLE
Fix sync use document loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kage1020/react-firebase-hooks",
-  "version": "0.1.2-canary.1",
+  "version": "0.1.2-canary.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kage1020/react-firebase-hooks",
-      "version": "0.1.2-canary.1",
+      "version": "0.1.2-canary.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@firebase/rules-unit-testing": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kage1020/react-firebase-hooks",
-  "version": "0.1.2-canary.1",
+  "version": "0.1.2-canary.2",
   "description": "React Hooks for Firebase",
   "author": "kage1020",
   "license": "Apache-2.0",

--- a/src/firestore/useDocument.ts
+++ b/src/firestore/useDocument.ts
@@ -30,17 +30,15 @@ export const useDocument = <T = DocumentData>(
   docRef?: DocumentReference<T> | null,
   options?: Options
 ): DocumentHook<T> => {
-  const { error, loading, reset, setError, setLoading, setValue, value } =
-    useLoadingValue<DocumentSnapshot<T>, FirestoreError>();
+  const { error, loading, reset, setError, setValue, value } = useLoadingValue<
+    DocumentSnapshot<T>,
+    FirestoreError
+  >();
   const ref = useIsFirestoreRefEqual<DocumentReference<T>>(docRef, reset);
 
   useEffect(() => {
-    if (!ref.current) {
-      setValue(undefined);
-      return;
-    }
+    if (!ref.current) return;
 
-    setLoading();
     const unsubscribe = options?.snapshotListenOptions
       ? onSnapshot(
           ref.current,
@@ -53,7 +51,7 @@ export const useDocument = <T = DocumentData>(
     return () => {
       unsubscribe();
     };
-  }, [ref.current, setLoading, setValue, setError]);
+  }, [ref.current, setValue, setError]);
 
   return [value as DocumentSnapshot<T>, loading, error];
 };
@@ -62,19 +60,17 @@ export const useDocumentOnce = <T = DocumentData>(
   docRef?: DocumentReference<T> | null,
   options?: OnceOptions
 ): DocumentOnceHook<T> => {
-  const { error, loading, reset, setError, setLoading, setValue, value } =
-    useLoadingValue<DocumentSnapshot<T>, FirestoreError>();
+  const { error, loading, reset, setError, setValue, value } = useLoadingValue<
+    DocumentSnapshot<T>,
+    FirestoreError
+  >();
   const isMounted = useIsMounted();
   const ref = useIsFirestoreRefEqual<DocumentReference<T>>(docRef, reset);
 
   const loadData = useCallback(
     async (reference?: DocumentReference<T> | null, options?: OnceOptions) => {
-      if (!reference) {
-        setValue(undefined);
-        return;
-      }
+      if (!reference) return;
 
-      setLoading();
       const get = getDocFnFromGetOptions(options?.getOptions);
 
       try {
@@ -88,7 +84,7 @@ export const useDocumentOnce = <T = DocumentData>(
         }
       }
     },
-    [isMounted, setLoading, setValue, setError]
+    [isMounted, setValue, setError]
   );
 
   const reloadData = useCallback(
@@ -97,10 +93,7 @@ export const useDocumentOnce = <T = DocumentData>(
   );
 
   useEffect(() => {
-    if (!ref.current) {
-      setValue(undefined);
-      return;
-    }
+    if (!ref.current) return;
 
     loadData(ref.current, options);
   }, [ref.current, options, loadData, setValue]);

--- a/src/util/useIsMounted.ts
+++ b/src/util/useIsMounted.ts
@@ -4,6 +4,7 @@ const useIsMounted = () => {
   const [isMounted, setIsMounted] = useState(false);
   useEffect(() => {
     setIsMounted(true);
+    return () => setIsMounted(false);
   }, []);
   return isMounted;
 };

--- a/src/util/useIsMounted.ts
+++ b/src/util/useIsMounted.ts
@@ -1,11 +1,9 @@
 import { useEffect, useState } from 'react';
 
 const useIsMounted = () => {
-  const [isMounted, setIsMounted] = useState(true);
+  const [isMounted, setIsMounted] = useState(false);
   useEffect(() => {
-    return () => {
-      setIsMounted(false);
-    };
+    setIsMounted(true);
   }, []);
   return isMounted;
 };

--- a/src/util/useLoadingValue.test.ts
+++ b/src/util/useLoadingValue.test.ts
@@ -17,14 +17,6 @@ describe('useLoadingValue', () => {
     it('sets error to undefined when setValue is called');
   });
 
-  describe('setLoading function', () => {
-    it('sets loading to true when setLoading is called');
-    
-    it('sets error to undefined when setLoading is called');
-    
-    it('preserves value when setLoading is called');
-  });
-
   describe('setError function', () => {
     it('sets error when setError is called');
     
@@ -52,7 +44,7 @@ describe('useLoadingValue', () => {
   });
 
   describe('callback stability', () => {
-    it('memoizes setValue, setError, setLoading with useCallback');
+    it('memoizes setValue, setError with useCallback');
     
     it('memoizes reset with getDefaultValue dependency');
   });

--- a/src/util/useLoadingValue.ts
+++ b/src/util/useLoadingValue.ts
@@ -5,7 +5,6 @@ export type LoadingValue<T, E> = {
   loading: boolean;
   reset: () => void;
   setError: (error: E) => void;
-  setLoading: () => void;
   setValue: (value?: T) => void;
   value?: T;
 };
@@ -17,14 +16,9 @@ type ReducerState<E> = {
 };
 
 type ErrorAction<E> = { type: 'error'; error: E };
-type LoadingAction = { type: 'loading' };
 type ResetAction = { type: 'reset'; defaultValue?: any };
 type ValueAction = { type: 'value'; value: any };
-type ReducerAction<E> =
-  | ErrorAction<E>
-  | LoadingAction
-  | ResetAction
-  | ValueAction;
+type ReducerAction<E> = ErrorAction<E> | ResetAction | ValueAction;
 
 const defaultState = (defaultValue?: any, isInitialLoad = true) => {
   return {
@@ -45,14 +39,8 @@ const reducer =
           loading: false,
           value: undefined,
         };
-      case 'loading':
-        return {
-          ...state,
-          error: undefined,
-          loading: true,
-        };
       case 'reset':
-        return defaultState(action.defaultValue, false);
+        return defaultState(action.defaultValue, state.loading);
       case 'value':
         return {
           ...state,
@@ -83,10 +71,6 @@ const useLoadingValue = <T, E>(
     dispatch({ type: 'error', error });
   }, []);
 
-  const setLoading = useCallback(() => {
-    dispatch({ type: 'loading' });
-  }, []);
-
   const setValue = useCallback((value?: T) => {
     dispatch({ type: 'value', value });
   }, []);
@@ -97,19 +81,10 @@ const useLoadingValue = <T, E>(
       loading: state.loading,
       reset,
       setError,
-      setLoading,
       setValue,
       value: state.value,
     }),
-    [
-      state.error,
-      state.loading,
-      reset,
-      setError,
-      setLoading,
-      setValue,
-      state.value,
-    ]
+    [state.error, state.loading, reset, setError, setValue, state.value]
   );
 };
 


### PR DESCRIPTION
This pull request simplifies and refines the loading state management logic in the Firestore document hooks by removing the `setLoading` function and its associated reducer action from the `useLoadingValue` utility. It also updates the usage of this hook throughout the codebase and adjusts related tests accordingly. The main goal is to streamline how loading states are handled, reducing unnecessary state transitions and code complexity.

Key changes include:

**Loading State Management Simplification:**

* Removed the `setLoading` function and its corresponding `'loading'` action from the `useLoadingValue` hook, its type definitions, and all usages. The loading state is now managed implicitly by value and error updates, reducing redundant state changes. [[1]](diffhunk://#diff-dab98d56e2d938d52b28ba519fb2367d38e25d4b887b2f9563149f44f0f1cea2L8) [[2]](diffhunk://#diff-dab98d56e2d938d52b28ba519fb2367d38e25d4b887b2f9563149f44f0f1cea2L20-R21) [[3]](diffhunk://#diff-dab98d56e2d938d52b28ba519fb2367d38e25d4b887b2f9563149f44f0f1cea2L48-R43) [[4]](diffhunk://#diff-dab98d56e2d938d52b28ba519fb2367d38e25d4b887b2f9563149f44f0f1cea2L86-L89) [[5]](diffhunk://#diff-dab98d56e2d938d52b28ba519fb2367d38e25d4b887b2f9563149f44f0f1cea2L100-R87)
* Updated the `useDocument` and `useDocumentOnce` hooks to remove calls to `setLoading` and to stop resetting the value to `undefined` when the document reference is missing, further simplifying their logic. [[1]](diffhunk://#diff-be3ac7b4d92eb659c29be9400506d70ea6877bc92eeea02bb297251b27487649L33-L43) [[2]](diffhunk://#diff-be3ac7b4d92eb659c29be9400506d70ea6877bc92eeea02bb297251b27487649L56-R54) [[3]](diffhunk://#diff-be3ac7b4d92eb659c29be9400506d70ea6877bc92eeea02bb297251b27487649L65-L77) [[4]](diffhunk://#diff-be3ac7b4d92eb659c29be9400506d70ea6877bc92eeea02bb297251b27487649L91-R87) [[5]](diffhunk://#diff-be3ac7b4d92eb659c29be9400506d70ea6877bc92eeea02bb297251b27487649L100-R96)

**Test Adjustments:**

* Removed tests related to the `setLoading` function and updated callback stability tests to reflect the removal of `setLoading`. [[1]](diffhunk://#diff-b3b5491d79ffd2080b2ddd04adf7ee323a412c481af695c5dc211744ca18aff7L20-L27) [[2]](diffhunk://#diff-b3b5491d79ffd2080b2ddd04adf7ee323a412c481af695c5dc211744ca18aff7L55-R47)

**Other Improvements:**

* Fixed the `useIsMounted` hook to initialize the mounted state as `false` and set it to `true` on mount, ensuring more accurate component lifecycle tracking.