### PR TITLE
chore: return null if document not exist

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,7 +1,5 @@
 {
   "projects": {
-    "default": "cascade-preview",
-    "dev": "cascade-preview",
-    "prod": "cascade-prod"
+    "default": "demo-noop"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @kage1020/react-firebase-hooks
 
-A fork of react-firebase-hooks with updated tooling and dependencies.
+A fork of react-firebase-hooks with updated bug fixing and dependencies.
 
 A set of reusable [React Hooks](https://reactjs.org/docs/hooks-intro.html) for [Firebase](https://firebase.google.com/).
 
@@ -39,6 +39,7 @@ import { useCollection } from '@kage1020/react-firebase-hooks/firestore';
 
 This library maintains the same excellent React Hooks API for Firebase while bringing modern tooling benefits:
 
+- 🐛 **Bug fixes** and improvements over the original package
 - ⚡ **Faster builds** with Vite instead of Rollup
 - 🧪 **Better DX** with Vitest instead of Jest
 - 📦 **Improved bundling** with optimized ESM/CJS outputs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @kage1020/react-firebase-hooks
 
-A fork of react-firebase-hooks with updated bug fixing and dependencies.
+A fork of react-firebase-hooks with updated bug fixes and dependencies.
 
 A set of reusable [React Hooks](https://reactjs.org/docs/hooks-intro.html) for [Firebase](https://firebase.google.com/).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kage1020/react-firebase-hooks",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kage1020/react-firebase-hooks",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@firebase/rules-unit-testing": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kage1020/react-firebase-hooks",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "React Hooks for Firebase",
   "author": "kage1020",
   "license": "Apache-2.0",

--- a/src/firestore/types.ts
+++ b/src/firestore/types.ts
@@ -36,7 +36,7 @@ export type CollectionOnceHook<T = DocumentData> = [
 ];
 export type CollectionDataHook<T = DocumentData> = [
   ...LoadingHook<T[], FirestoreError>,
-  QuerySnapshot<T> | undefined,
+  QuerySnapshot<T> | null | undefined,
 ];
 export type CollectionDataOnceHook<T = DocumentData> = [
   ...CollectionDataHook<T>,
@@ -53,7 +53,7 @@ export type DocumentOnceHook<T = DocumentData> = [
 ];
 export type DocumentDataHook<T = DocumentData> = [
   ...LoadingHook<T, FirestoreError>,
-  DocumentSnapshot<T> | undefined,
+  DocumentSnapshot<T> | null | undefined,
 ];
 export type DocumentDataOnceHook<T = DocumentData> = [
   ...DocumentDataHook<T>,

--- a/src/firestore/useCollection.ts
+++ b/src/firestore/useCollection.ts
@@ -137,17 +137,21 @@ export const useCollectionDataOnce = <T = DocumentData>(
 };
 
 const getValuesFromSnapshots = <T>(
-  snapshots: QuerySnapshot<T> | undefined,
+  snapshots: QuerySnapshot<T> | null | undefined,
   options?: SnapshotOptions,
   initialValue?: T[]
-): T[] | undefined => {
-  return useMemo(
-    () =>
-      (snapshots?.docs.map((doc) => doc.data(options)) ?? initialValue) as
-        | T[]
-        | undefined,
-    [snapshots, options]
-  );
+): T[] | null | undefined => {
+  return useMemo(() => {
+    if (!snapshots) {
+      return initialValue ?? undefined;
+    }
+
+    if (snapshots.docs.length === 0) {
+      return initialValue ?? null;
+    }
+
+    return snapshots.docs.map((doc) => doc.data(options));
+  }, [snapshots, options, initialValue]);
 };
 
 const getDocsFnFromGetOptions = (

--- a/src/firestore/useDocument.test.ts
+++ b/src/firestore/useDocument.test.ts
@@ -521,7 +521,7 @@ describe('useDocumentData', () => {
       });
     });
 
-    it('returns undefined when document does not exist', async () => {
+    it('returns null when document does not exist (without initialValue)', async () => {
       const mockSnapshot = {
         exists: () => false,
         data: () => undefined,
@@ -535,7 +535,7 @@ describe('useDocumentData', () => {
       const { result } = renderHook(() => useDocumentData(mockDocRef));
 
       await waitFor(() => {
-        expect(result.current[0]).toBeUndefined();
+        expect(result.current[0]).toBeNull();
       });
     });
 
@@ -796,6 +796,21 @@ describe('useDocumentDataOnce', () => {
   });
 
   describe('initialValue combination', () => {
+    it('returns null when document does not exist (without initialValue)', async () => {
+      const mockSnapshot = {
+        exists: () => false,
+        data: () => undefined,
+      } as unknown as DocumentSnapshot;
+
+      vi.mocked(getDoc).mockResolvedValue(mockSnapshot);
+
+      const { result } = renderHook(() => useDocumentDataOnce(mockDocRef));
+
+      await waitFor(() => {
+        expect(result.current[0]).toBeNull();
+      });
+    });
+
     it('returns initialValue when document does not exist', async () => {
       const initialValue = { name: 'initial' };
       const mockSnapshot = {

--- a/src/firestore/useDocument.ts
+++ b/src/firestore/useDocument.ts
@@ -149,12 +149,20 @@ const getDocFnFromGetOptions = (
 };
 
 const getValueFromSnapshot = <T>(
-  snapshot: DocumentSnapshot<T> | undefined,
+  snapshot: DocumentSnapshot<T> | null | undefined,
   options?: SnapshotOptions,
   initialValue?: T
-): T | undefined => {
-  return useMemo(
-    () => (snapshot?.data(options) ?? initialValue) as T | undefined,
-    [snapshot, options, initialValue]
-  );
+): T | null | undefined => {
+  return useMemo(() => {
+    if (!snapshot) {
+      return initialValue ?? undefined;
+    }
+
+    if (!snapshot.exists()) {
+      return initialValue ?? null;
+    }
+
+    const data = snapshot.data(options);
+    return (data ?? initialValue) as T | undefined;
+  }, [snapshot, options, initialValue]);
 };

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,4 +1,4 @@
 export { useLoadingValue } from './useLoadingValue';
 export * from './refHooks';
 
-export type LoadingHook<T, E> = [T | undefined, boolean, E | undefined];
+export type LoadingHook<T, E> = [T | null | undefined, boolean, E | undefined];

--- a/src/util/useLoadingValue.test.ts
+++ b/src/util/useLoadingValue.test.ts
@@ -2,50 +2,54 @@ import { describe, it } from 'vitest';
 
 describe('useLoadingValue', () => {
   describe('initialization', () => {
-    it('initializes with undefined value and loading true when getDefaultValue is not provided');
-    
-    it('initializes with returned value and loading false when getDefaultValue is provided');
-    
+    it(
+      'initializes with undefined value and loading true when getDefaultValue is not provided'
+    );
+
+    it(
+      'initializes with returned value and loading false when getDefaultValue is provided'
+    );
+
     it('initializes with loading true when getDefaultValue returns null');
   });
 
   describe('setValue function', () => {
     it('updates value when setValue is called');
-    
+
     it('sets loading to false when setValue is called');
-    
+
     it('sets error to undefined when setValue is called');
   });
 
   describe('setError function', () => {
     it('sets error when setError is called');
-    
+
     it('sets loading to false when setError is called');
-    
+
     it('sets value to undefined when setError is called');
   });
 
   describe('reset function', () => {
     it('returns to initial state when reset is called');
-    
+
     it('re-executes getDefaultValue when reset is called');
-    
+
     it('sets loading to false when reset is called');
   });
 
   describe('useReducer integration', () => {
     it('reducer function correctly handles error action');
-    
+
     it('reducer function correctly handles loading action');
-    
+
     it('reducer function correctly handles value action');
-    
+
     it('reducer function correctly handles reset action');
   });
 
   describe('callback stability', () => {
     it('memoizes setValue, setError with useCallback');
-    
+
     it('memoizes reset with getDefaultValue dependency');
   });
 });


### PR DESCRIPTION
This pull request primarily improves the handling of missing Firestore documents and collections by standardizing the return value to `null` (instead of `undefined`) when a document or collection does not exist. It also updates type definitions, tests, and documentation to reflect this change. Additionally, there are minor updates to project configuration and documentation.

**Firestore hook return value improvements:**

* Standardized return values for missing Firestore documents and collections to `null` instead of `undefined` in hooks such as `useDocumentData`, `useDocumentDataOnce`, and `useCollectionDataOnce`. This is reflected in the implementation of `getValueFromSnapshot` and `getValuesFromSnapshots`. [[1]](diffhunk://#diff-9642962165dc0f476e4b73548e92d619479850f0e0d12effca21a976c08568d1L140-R154) [[2]](diffhunk://#diff-be3ac7b4d92eb659c29be9400506d70ea6877bc92eeea02bb297251b27487649L152-R167)
* Updated type definitions in `src/firestore/types.ts` and `src/util/index.ts` to allow `null` as a possible value in relevant hook return types. [[1]](diffhunk://#diff-dd24bc365f84933610b57dca06e6b07a547173ca1ec2482c89d7152209b1e6abL39-R39) [[2]](diffhunk://#diff-dd24bc365f84933610b57dca06e6b07a547173ca1ec2482c89d7152209b1e6abL56-R56) [[3]](diffhunk://#diff-17577692954f298c8a67ce42f74223aa47e205f0be1b78fdbb6c3e5b89d9bcf5L4-R4)

**Testing updates:**

* Adjusted and added tests in `src/firestore/useDocument.test.ts` to assert that hooks return `null` when a document does not exist, ensuring correct behavior. [[1]](diffhunk://#diff-c274bf29a780ff5ae8f7aadbe8104777040995885078f5314209481212facd0aL524-R524) [[2]](diffhunk://#diff-c274bf29a780ff5ae8f7aadbe8104777040995885078f5314209481212facd0aL538-R538) [[3]](diffhunk://#diff-c274bf29a780ff5ae8f7aadbe8104777040995885078f5314209481212facd0aR799-R813)

**Documentation and configuration:**

* Updated the `README.md` to highlight bug fixes and improvements over the original package. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42)
* Changed the default Firebase project in `.firebaserc` to `demo-noop`.
* Minor formatting improvements in test descriptions for clarity.